### PR TITLE
fix offer token not change when switching chain

### DIFF
--- a/src/components/page/DcaOrder.tsx
+++ b/src/components/page/DcaOrder.tsx
@@ -14,7 +14,7 @@ import {
 
 import useBalance from "@/hooks/useBalance";
 import { useWarpGetConfig } from "@/hooks/useWarpGetConfig";
-import { SelectPool } from "@/components/warp/SelectPool";
+import SelectPool from "@/components/warp/SelectPool";
 import { WarpJobs } from "@/components/warp/WarpJobs";
 import { getTokenDecimals } from "@/utils/token";
 import { useSimulateSwap } from "@/hooks/useAstroportSimulateSwapFromPool";
@@ -50,6 +50,11 @@ export const DcaOrderPage = () => {
   const [returnToken, setReturnToken] = useState<Token>(
     chainConfig.pools[0].token2
   );
+
+  useEffect(() => {
+    setOfferToken(chainConfig.pools[0].token1);
+    setReturnToken(chainConfig.pools[0].token2);
+  }, [chainConfig]);
 
   const [offerTokenAmount, setOfferTokenAmount] = useState("1");
   const [totalOfferTokenAmount, setTotalOfferTokenAmount] = useState("2");

--- a/src/components/page/LimitOrder.tsx
+++ b/src/components/page/LimitOrder.tsx
@@ -15,7 +15,7 @@ import {
 
 import useBalance from "@/hooks/useBalance";
 import { useWarpGetConfig } from "@/hooks/useWarpGetConfig";
-import { SelectPool } from "@/components/warp/SelectPool";
+import SelectPool from "@/components/warp/SelectPool";
 import { WarpJobs } from "@/components/warp/WarpJobs";
 import { useSimulateSwap } from "@/hooks/useAstroportSimulateSwapFromPool";
 import { WarpCreateJobAstroportLimitOrder } from "@/components/warp/WarpCreateJobAstroportLimitOrder";
@@ -53,6 +53,11 @@ export const LimitOrderPage = () => {
   const [returnToken, setReturnToken] = useState<Token>(
     chainConfig.pools[0].token2
   );
+
+  useEffect(() => {
+    setOfferToken(chainConfig.pools[0].token1);
+    setReturnToken(chainConfig.pools[0].token2);
+  }, [chainConfig]);
 
   const [offerTokenAmount, setOfferTokenAmount] = useState("1");
   const [returnTokenAmount, setReturnTokenAmount] = useState("1");

--- a/src/components/warp/SelectPool.tsx
+++ b/src/components/warp/SelectPool.tsx
@@ -4,17 +4,15 @@ import { Select, Flex } from "@chakra-ui/react";
 import { Token } from "@/utils/constants";
 import ChainContext from "@/contexts/ChainContext";
 
-type SelectPoolProps = {
-  onChangeOfferToken: (updatedOfferToken: Token) => void;
-  onChangeReturnToken: (updatedReturnToken: Token) => void;
-  onChangePoolAddress: (updatedPoolAddress: string) => void;
-};
-
-export const SelectPool = ({
+const SelectPool = ({
   onChangeOfferToken,
   onChangeReturnToken,
   onChangePoolAddress,
-}: SelectPoolProps) => {
+}: {
+  onChangeOfferToken: (updatedOfferToken: Token) => void;
+  onChangeReturnToken: (updatedReturnToken: Token) => void;
+  onChangePoolAddress: (updatedPoolAddress: string) => void;
+}) => {
   const { chainConfig } = useContext(ChainContext);
   const pools = chainConfig.pools;
 
@@ -73,3 +71,5 @@ export const SelectPool = ({
     </Flex>
   );
 };
+
+export default SelectPool;


### PR DESCRIPTION
when user switches the chain, we should update the available trading pairs and update the default offer token and return token to first trading pair.